### PR TITLE
fix(ts) - add null typing to replacer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,5 +6,5 @@
 */
 
 declare module 'json-beautify' {
-  export default function beautify (value: any, replacer: Function | object | any[], space: number | string, limit?: number): string
+  export default function beautify (value: any, replacer: Function | object | any[] | null, space: number | string, limit?: number): string
 }


### PR DESCRIPTION
Warm welcome again!

Last time i made a small mistake.

Basing on your examples: Replacer can be null object. I forgot it to add in types.

```
console.log(beautify(obj, null, 2, 100));
```

Sorry for wasting your time. Thank you! 